### PR TITLE
feat: change the base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM nginx:1.21.0
+FROM nginx:1.23.2-alpine
 
 # Remove sym links from nginx image
 RUN rm /var/log/nginx/access.log
 RUN rm /var/log/nginx/error.log
 
 # Install logrotate
-RUN apt-get update && apt-get -y install logrotate && apt-get -y install vim
+RUN apk update && apk add logrotate vim
 
 COPY crontab /etc/crontab
+COPY nginx-logrotate /etc/logrotate.d/nginx
 
 # Start nginx and cron as a service
-CMD service cron start && nginx -g 'daemon off;'
+CMD crond -b && nginx -g 'daemon off;'

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,7 +6,4 @@ services:
         image: proxynginx:latest
         restart: "no"
         ports:
-          - 80:80
-        volumes:
-          - ./log:/var/log/nginx
-          - ./nginx-logrotate:/etc/nginx-logrotate
+          - 8080:80


### PR DESCRIPTION
We discovered that the base nginx image has 4 critical issues even with the latest version so this PR changes the base nginx image to alpine version

Normal version:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/1266477/202646559-cc8fd1ca-9bae-4a92-ae4f-0e6071090d1c.png">

Vs Alpine version:
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/1266477/202646608-ddae14c0-76d9-416e-b64d-da6cbdaff787.png">
